### PR TITLE
Visual-Studio приспособление

### DIFF
--- a/Tennisi.Xunit.ParallelTestFramework.Tests/AssemblyInfoExtractorTests.cs
+++ b/Tennisi.Xunit.ParallelTestFramework.Tests/AssemblyInfoExtractorTests.cs
@@ -1,0 +1,25 @@
+﻿using Xunit;
+
+namespace Tennisi.Xunit.ParallelTestFramework.Tests;
+
+public class AssemblyInfoExtractorTests
+{
+    [Theory]
+    [InlineData("Тенниси.Xunit.ParallelTestFramework.Tests, Version=1.0.0.0", "Тенниси.Xunit.ParallelTestFramework.Tests, Version=1.0.0.0")]
+    [InlineData("Тенниси,   Юнит,   ТестФреймворк, тесты, Version=1.0.0-beta7,  Culture=neutral", "Тенниси, Юнит, ТестФреймворк, тесты, Version=1.0.0-beta7")]
+    [InlineData("Тенниси, Юнит, ТестФреймворк, тесты, Version=1.0.0.1, PublicKeyToken=abcdef1234567890", "Тенниси, Юнит, ТестФреймворк, тесты, Version=1.0.0.1")]
+    [InlineData("\t\"Тенниси, Xunit, ParallelTestFramework, Tests\", Version=1.2.3-alpha, Culture=en-US", "Тенниси, Xunit, ParallelTestFramework, Tests, Version=1.2.3-alpha")]
+    [InlineData("Тенниси.Xunit, Version=2.1.0.0, PublicKeyToken=7a5c1e8d5b4e6ef1", "Тенниси.Xunit, Version=2.1.0.0")]
+    [InlineData("  Тенниси,   Юнит, ТестФреймворк, тесты, Version=2.0.0.0, Culture=ru-RU  ", "Тенниси, Юнит, ТестФреймворк, тесты, Version=2.0.0.0")]
+    [InlineData("Тенниси.Xunit, Version=1.0.0.0, Culture=fr-FR, PublicKeyToken=12ab34cd56ef78gh", "Тенниси.Xunit, Version=1.0.0.0")]
+    [InlineData("Тенниси, Юнит, ТестФреймворк, тесты, Version=1.0.0-beta,  PublicKeyToken=aabbccddeeff0011", "Тенниси, Юнит, ТестФреймворк, тесты, Version=1.0.0-beta")]
+    [InlineData("Тенниси.Xunit,  Version= 2.1.0.0,  Culture=de-DE,   PublicKeyToken=null", "Тенниси.Xunit, Version=2.1.0.0")]
+    [InlineData("Тенниси.Xunit.ParallelTestFramework.Tests, Version= 1.0.0.0\t, Culture=ja-JP", "Тенниси.Xunit.ParallelTestFramework.Tests, Version=1.0.0.0")]
+    [InlineData("Тенниси.Xunit, Version=1.0.0-beta3, PublicKeyToken=abcdef", "Тенниси.Xunit, Version=1.0.0-beta3")]
+    [InlineData("Тенниси, Юнит, ТестФреймворк, тесты, Version=3.0.0.0-beta1, Culture=ru-RU", "Тенниси, Юнит, ТестФреймворк, тесты, Version=3.0.0.0-beta1")]
+    public void ExtractNameAndVersion_VariousAssemblyNames_ReturnsExpected(string input, string expected)
+    {
+        var result = AssemblyInfoExtractor.ExtractNameAndVersion(input);
+        Assert.Equal(expected, result);
+    }
+}

--- a/Tennisi.Xunit.ParallelTestFramework/AssemblyInfoExtractor.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/AssemblyInfoExtractor.cs
@@ -1,0 +1,33 @@
+﻿namespace Tennisi.Xunit;
+
+internal static class AssemblyInfoExtractor
+{
+    private static readonly char[] Separator = { ',' };
+
+    public static string ExtractNameAndVersion(string input)
+    {
+        var parts = input.Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+        string namePart = string.Empty;
+        string versionPart = string.Empty;
+
+        foreach (var part in parts)
+        {
+            var trimmedPart = part.Trim();
+            if (trimmedPart.StartsWith("Version=", StringComparison.OrdinalIgnoreCase))
+            {
+                versionPart = trimmedPart["Version=".Length..].Trim();
+            }
+            else if (!trimmedPart.StartsWith("Culture=", StringComparison.OrdinalIgnoreCase) &&
+                     !trimmedPart.StartsWith("PublicKeyToken=", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!string.IsNullOrEmpty(namePart))
+                {
+                    namePart += ", ";
+                }
+                namePart += trimmedPart.Trim('"');
+            }
+        }
+
+        return $"{namePart}, Version={versionPart}".TrimEnd(',', ' ');
+    }
+}

--- a/Tennisi.Xunit.ParallelTestFramework/ParallelSettings.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/ParallelSettings.cs
@@ -53,16 +53,4 @@ internal static class ParallelSettings
             return new TestAsm(force: result, opts);
         });
     }
-    
-    private static class AssemblyInfoExtractor
-    {
-        internal static string ExtractNameAndVersion(string assemblyName)
-        {
-            var parts = assemblyName.Split(',');
-
-            var name = parts.FirstOrDefault(p => !p.Contains('='))?.Trim();
-            var version = parts.FirstOrDefault(p => p.Trim().StartsWith("Version="))?.Split('=')[1].Trim();
-            return $"{name}, Version={version}";
-        }
-    }
 }


### PR DESCRIPTION
Юлия Лобас На тестах BettingShop.Admin.Tests обнаружила, что VS посылает неполный AssemblyName в два разных метода (первый когда находит assembly, второй когда уточняет настроку) в класс ParallelSetttings. Из за чего не может найтись настройка. Ситуация вопсроизводится всегда. Такое решение должно помочоь от Assembly остается только имя и версия. Может и криво, но по идее, железно