### PR TITLE
Feature/BOX-X Retry mechanics for unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ ___
 
 ### Настройка DisableTestParallelization отношения к этой библиотеке не имеет.
 
+### Retrying tests in MonoRepo
+
+Для подробной информации см. в метаданных Tennisi.Xunit.ParallelTestFramework
+RetryFactAttribute, RetryTheoryAttribute, RetryClassAttribute
+
+RetryFactAttribute используется вместо стандратного FactAttribute с указанием макс. кол-ва попыток.
+
+RetryTheoryAttribute использется вместо стандратного TheoryAttrubute с указанием макс. кол-ва попыток. [Работает только с xunit.discovery.PreEnumerateTheories или FullTestParallelization]
+
+RetryClassAttribute использется для указания макс. кол-ва попыток всем фактам и теориям в тестовом классе, если они не определены для тестовых методов.
+
+В Логах ищи test retrying... что бы найти подозрительные тесты
+
 
 
 Tennisi! By default, xUnit runs all test cases in a test class synchronously.

--- a/Tennisi.Xunit.ParallelTestFramework.Tests/RetryTest.cs
+++ b/Tennisi.Xunit.ParallelTestFramework.Tests/RetryTest.cs
@@ -5,7 +5,7 @@ namespace Tennisi.Xunit.ParallelTestFramework.Tests;
 
 public class RetryTest
 {
-    private const int RetryN = 3;
+    private const int RetryN = 5;
 
     public class CounterFixture
     {

--- a/Tennisi.Xunit.ParallelTestFramework.Tests/RetryTest.cs
+++ b/Tennisi.Xunit.ParallelTestFramework.Tests/RetryTest.cs
@@ -1,0 +1,154 @@
+﻿using Xunit;
+using Xunit.Abstractions;
+
+namespace Tennisi.Xunit.ParallelTestFramework.Tests;
+
+public class RetryTest
+{
+    private const int RetryN = 3;
+
+    public class CounterFixture
+    {
+        public int RunCount;
+    }
+
+    [RetryClass(retryCount: RetryN)]
+    public class ClassFactSample : IClassFixture<CounterFixture>
+    {
+        private readonly CounterFixture _counter;
+
+        public ClassFactSample(CounterFixture counter)
+        {
+            _counter = counter;
+
+            counter.RunCount++;
+        }
+
+        [Fact]
+        public void WillPassTheN_Time()
+        {
+            Assert.Equal(RetryN, _counter.RunCount);
+        }
+    }
+
+    [RetryClass(retryCount: RetryN)]
+    public class ClassPassTheorySample : IClassFixture<CounterFixture>
+    {
+        private readonly CounterFixture _counter;
+
+        public ClassPassTheorySample(CounterFixture counter)
+        {
+            _counter = counter;
+
+            counter.RunCount++;
+        }
+
+        [Theory]
+        [InlineData(RetryN)]
+        public void WillPassTheN_Time(int expectedCount)
+        {
+            var val = _counter.RunCount == expectedCount;
+            Assert.True(val);
+        }
+    }
+
+    [RetryClass(retryCount: RetryN)]
+    public class ClassFailedTheorySample : IClassFixture<CounterFixture>
+    {
+        private readonly CounterFixture _counter;
+
+        public ClassFailedTheorySample(CounterFixture counter)
+        {
+            _counter = counter;
+
+            counter.RunCount++;
+        }
+
+        [Theory]
+        [InlineData(RetryN - 1)]
+        public void WillPassTheN_Time(int expectedCount)
+        {
+            var val = _counter.RunCount == expectedCount;
+            Assert.False(val);
+        }
+    }
+
+    public class FactSample : IClassFixture<CounterFixture>
+    {
+        private readonly CounterFixture _counter;
+
+        public FactSample(CounterFixture counter)
+        {
+            _counter = counter;
+
+            counter.RunCount++;
+        }
+
+        [Fact]
+        public void WillFail()
+        {
+            Assert.NotEqual(RetryN, _counter.RunCount);
+        }
+    }
+
+    public class RetryFactSample : IClassFixture<CounterFixture>
+    {
+        private readonly CounterFixture _counter;
+
+        public RetryFactSample(CounterFixture counter)
+        {
+            _counter = counter;
+
+            counter.RunCount++;
+        }
+
+        [RetryFact(retryCount: RetryN)]
+        public void WillPassTheN_Time()
+        {
+            Assert.Equal(RetryN, _counter.RunCount);
+        }
+    }
+
+    public class RetryPassTheorySample : IClassFixture<CounterFixture>
+    {
+        private readonly CounterFixture _counter;
+        
+        private readonly ITestOutputHelper _output;
+
+        public RetryPassTheorySample(CounterFixture counter, ITestOutputHelper helper)
+        {
+            _counter = counter;
+            _output = helper;
+
+            counter.RunCount++;
+        }
+
+        [RetryTheory(retryCount: RetryN)]
+        [InlineData(RetryN)]
+        public void TheoryMethodShouldPass(int expectedCount)
+        {
+            _output.WriteLine(_counter.RunCount.ToString());
+            Assert.True(_counter.RunCount >= expectedCount);
+        }
+    }
+
+    public class RetryFailTheorySample : IClassFixture<CounterFixture>
+    {
+        private readonly CounterFixture _counter;
+
+        public RetryFailTheorySample(CounterFixture counter)
+        {
+            _counter = counter;
+
+            counter.RunCount++;
+        }
+
+        [RetryTheory(retryCount: RetryN)]
+        [InlineData(RetryN -1)]
+        public void TheoryMethodShouldFail(int expectedCount)
+        {
+            var val = _counter.RunCount == expectedCount;
+            Assert.False(val);
+        }
+    }
+}

--- a/Tennisi.Xunit.ParallelTestFramework.Tests/Tennisi.Xunit.ParallelTestFramework.Tests.csproj
+++ b/Tennisi.Xunit.ParallelTestFramework.Tests/Tennisi.Xunit.ParallelTestFramework.Tests.csproj
@@ -21,12 +21,12 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.9.2" />
   </ItemGroup>
       
   <ItemGroup>

--- a/Tennisi.Xunit.ParallelTestFramework/DelayedMessageBus.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/DelayedMessageBus.cs
@@ -1,0 +1,28 @@
+﻿using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Tennisi.Xunit;
+
+internal class DelayedMessageBus : IMessageBus
+{
+    private readonly IMessageBus _innerBus;
+    private readonly List<IMessageSinkMessage> _messages = new();
+
+    public DelayedMessageBus(IMessageBus innerBus)
+    {
+        _innerBus = innerBus;
+    }
+
+    public bool QueueMessage(IMessageSinkMessage message)
+    {
+        lock (_messages)
+            _messages.Add(message);
+        return true;
+    }
+
+    public void Dispose()
+    {
+        foreach (var message in _messages)
+            _innerBus.QueueMessage(message);
+    }
+}

--- a/Tennisi.Xunit.ParallelTestFramework/ParallelTestFrameworkDiscoverer.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/ParallelTestFrameworkDiscoverer.cs
@@ -1,4 +1,7 @@
-﻿using Xunit.Abstractions;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Xunit;
+using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Tennisi.Xunit;
@@ -6,16 +9,78 @@ namespace Tennisi.Xunit;
 public class ParallelTestFrameworkDiscoverer: XunitTestFrameworkDiscoverer
 {
     private readonly IAssemblyInfo _assemblyInfo;
+
     public ParallelTestFrameworkDiscoverer(IAssemblyInfo assemblyInfo, ISourceInformationProvider sourceProvider, IMessageSink diagnosticMessageSink, IXunitTestCollectionFactory collectionFactory = null) : base(assemblyInfo, sourceProvider, diagnosticMessageSink, collectionFactory)
     {
         _assemblyInfo = assemblyInfo;
     }
 
-    protected override bool FindTestsForMethod(ITestMethod testMethod, bool includeSourceInformation, IMessageBus messageBus,
+    protected override bool FindTestsForMethod(ITestMethod testMethod, bool includeSourceInformation,
+        IMessageBus messageBus,
         ITestFrameworkDiscoveryOptions discoveryOptions)
     {
-        ParallelSettings.RefineParallelSetting(_assemblyInfo.Name, discoveryOptions, "xunit.discovery.PreEnumerateTheories", true);
-        return base.FindTestsForMethod(testMethod, includeSourceInformation, messageBus, discoveryOptions);
+        ParallelSettings.RefineParallelSetting(_assemblyInfo.Name, discoveryOptions,
+            "xunit.discovery.PreEnumerateTheories", true);
+        
+        if (!testMethod.ShouldUseClassRetry(out var retryCount))
+            return base.FindTestsForMethod(testMethod, includeSourceInformation, messageBus, discoveryOptions);
+
+        return FindTestsForMethod2(testMethod, includeSourceInformation, messageBus, discoveryOptions, retryCount);
+    }
+
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
+    protected virtual bool FindTestsForMethod2(ITestMethod testMethod, bool includeSourceInformation,
+        IMessageBus messageBus,
+        ITestFrameworkDiscoveryOptions discoveryOptions, int retryCount)
+    {
+        var factAttributesRaw = testMethod.Method.GetCustomAttributes(typeof(FactAttribute));
+        var factAttributes = (factAttributesRaw as List<IAttributeInfo>) ?? factAttributesRaw.ToList();
+        if (factAttributes.Count > 1)
+        {
+            var message = string.Format(CultureInfo.CurrentCulture,
+                "Test method '{0}.{1}' has multiple [Fact]-derived attributes", testMethod.TestClass.Class.Name,
+                testMethod.Method.Name);
+            var testCase = new ExecutionErrorTestCase(DiagnosticMessageSink, TestMethodDisplay.ClassAndMethod,
+                TestMethodDisplayOptions.None, testMethod, message);
+                return ReportDiscoveredTestCase(testCase, includeSourceInformation, messageBus);
+        }
+
+        var factAttribute = factAttributes.FirstOrDefault();
+        if (factAttribute == null)
+            return true;
+
+        var factAttributeType = (factAttribute as IReflectionAttributeInfo)?.Attribute.GetType();
+
+        Type? discovererType = null;
+        if (factAttributeType == null || !DiscovererTypeCache.TryGetValue(factAttributeType, out discovererType))
+        {
+            var testCaseDiscovererAttribute =
+                factAttribute.GetCustomAttributes(typeof(XunitTestCaseDiscovererAttribute)).FirstOrDefault();
+            if (testCaseDiscovererAttribute != null)
+            {
+                var args = testCaseDiscovererAttribute.GetConstructorArguments().Cast<string>().ToList();
+                discovererType = SerializationHelper.GetType(args[1], args[0]);
+            }
+
+            if (factAttributeType != null)
+                DiscovererTypeCache[factAttributeType] = discovererType;
+        }
+
+        if (discovererType == null)
+            return true;
+
+        var discoverer = GetDiscoverer(discovererType);
+        if (discoverer == null)
+            return true;
+
+        foreach (var testCase in discoverer.Discover(discoveryOptions, testMethod, factAttribute))
+        {
+            var retryTestCase = new RetryTestCase(testCase, retryCount);
+            if (!ReportDiscoveredTestCase(retryTestCase, includeSourceInformation, messageBus))
+                return false;
+        }
+
+        return true;
     }
 
     protected override bool FindTestsForType(ITestClass testClass, bool includeSourceInformation, IMessageBus messageBus,

--- a/Tennisi.Xunit.ParallelTestFramework/ParallelTestFrameworkDiscoverer.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/ParallelTestFrameworkDiscoverer.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
+﻿using System.Globalization;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -27,8 +26,7 @@ public class ParallelTestFrameworkDiscoverer: XunitTestFrameworkDiscoverer
 
         return FindTestsForMethod2(testMethod, includeSourceInformation, messageBus, discoveryOptions, retryCount);
     }
-
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope")]
+    
     protected virtual bool FindTestsForMethod2(ITestMethod testMethod, bool includeSourceInformation,
         IMessageBus messageBus,
         ITestFrameworkDiscoveryOptions discoveryOptions, int retryCount)
@@ -40,7 +38,7 @@ public class ParallelTestFrameworkDiscoverer: XunitTestFrameworkDiscoverer
             var message = string.Format(CultureInfo.CurrentCulture,
                 "Test method '{0}.{1}' has multiple [Fact]-derived attributes", testMethod.TestClass.Class.Name,
                 testMethod.Method.Name);
-            var testCase = new ExecutionErrorTestCase(DiagnosticMessageSink, TestMethodDisplay.ClassAndMethod,
+            using var testCase = new ExecutionErrorTestCase(DiagnosticMessageSink, TestMethodDisplay.ClassAndMethod,
                 TestMethodDisplayOptions.None, testMethod, message);
                 return ReportDiscoveredTestCase(testCase, includeSourceInformation, messageBus);
         }

--- a/Tennisi.Xunit.ParallelTestFramework/ParallelTestMethodRunner.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/ParallelTestMethodRunner.cs
@@ -50,8 +50,7 @@ public sealed class ParallelTestMethodRunner : XunitTestMethodRunner
         {
             foreach (var xunitTestCase in TestCases)
             {
-                var testCase = (XunitTestCase)xunitTestCase;
-                summary.Aggregate(await RunTestCaseAsync2(testCase, disableParallelization));
+                summary.Aggregate(await RunTestCaseAsync2(xunitTestCase, disableParallelization));
                 if (CancellationTokenSource.IsCancellationRequested)
                     break;
             }

--- a/Tennisi.Xunit.ParallelTestFramework/RetryCache.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/RetryCache.cs
@@ -5,36 +5,41 @@ namespace Tennisi.Xunit;
 
 internal static class RetryCache
 {
-    private static readonly ConcurrentDictionary<ITestMethod, bool> MethodCache = new();
-    
-    private static readonly ConcurrentDictionary<ITypeInfo, int> TypeCache = new();
-    
+    private static readonly ConcurrentDictionary<(ITestMethod Method, ITypeInfo Class), RetryEntry> Cache = new();
+
     internal static bool ShouldUseClassRetry(this ITestMethod testMethod, out int retryCount)
     {
-        var result = MethodCache.GetOrAdd(testMethod, mtd =>
+        var entry = Cache.GetOrAdd((testMethod, testMethod.TestClass.Class), tuple =>
         {
-            var isMethodAttribute = mtd.Method.GetCustomAttributes(typeof(RetryFactAttribute)).Any()
-                                    || mtd.Method.GetCustomAttributes(typeof(RetryTheoryAttribute)).Any();
-
-            return isMethodAttribute;
-        });
-
-        if (!result)
-        {
-            var cnt = TypeCache.GetOrAdd(testMethod.TestClass.Class, cls =>
+            var mtd = tuple.Method;
+            var hasMethodAttribute = mtd.Method.GetCustomAttributes(typeof(RetryFactAttribute)).Any()
+                                     || mtd.Method.GetCustomAttributes(typeof(RetryTheoryAttribute)).Any();
+            if (hasMethodAttribute)
             {
-                var retryClassAttribute = cls
-                    .GetCustomAttributes(typeof(RetryClassAttribute))
-                    .FirstOrDefault();
-                return retryClassAttribute.GetRetryCountOrDefault();
-            });
-            if (!cnt.IsDefaultRetryCount())
-            {
-                retryCount = cnt;
-                return true;
+                return new RetryEntry(false, int.MinValue);
             }
+            var cls = tuple.Class;
+            var retryClassAttribute = cls.GetCustomAttributes(typeof(RetryClassAttribute)).FirstOrDefault();
+            if (retryClassAttribute == null)
+                return new RetryEntry(false, int.MinValue);
+            var retryCount = retryClassAttribute.GetRetryCountOrDefault();
+            var hasRetry = !retryCount.IsDefaultRetryCount();
+            return new RetryEntry(hasRetry, retryCount);
+        });
+        
+        retryCount = entry.RetryCount;
+        return entry.HasRetry;
+    }
+
+    private readonly struct RetryEntry
+    {
+        internal bool HasRetry { get; }
+        internal int RetryCount { get; }
+
+        internal RetryEntry(bool hasRetry, int retryCount)
+        {
+            HasRetry = hasRetry;
+            RetryCount = retryCount;
         }
-        retryCount = int.MinValue;
-        return false;
     }
 }

--- a/Tennisi.Xunit.ParallelTestFramework/RetryCache.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/RetryCache.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Concurrent;
+using Xunit.Abstractions;
+
+namespace Tennisi.Xunit;
+
+internal static class RetryCache
+{
+    private static readonly ConcurrentDictionary<ITestMethod, bool> MethodCache = new();
+    
+    private static readonly ConcurrentDictionary<ITypeInfo, int> TypeCache = new();
+    
+    internal static bool ShouldUseClassRetry(this ITestMethod testMethod, out int retryCount)
+    {
+        var result = MethodCache.GetOrAdd(testMethod, mtd =>
+        {
+            var isMethodAttribute = mtd.Method.GetCustomAttributes(typeof(RetryFactAttribute)).Any()
+                                    || mtd.Method.GetCustomAttributes(typeof(RetryTheoryAttribute)).Any();
+
+            return isMethodAttribute;
+        });
+
+        if (!result)
+        {
+            var cnt = TypeCache.GetOrAdd(testMethod.TestClass.Class, cls =>
+            {
+                var retryClassAttribute = cls
+                    .GetCustomAttributes(typeof(RetryClassAttribute))
+                    .FirstOrDefault();
+                return retryClassAttribute.GetRetryCountOrDefault();
+            });
+            if (!cnt.IsDefaultRetryCount())
+            {
+                retryCount = cnt;
+                return true;
+            }
+        }
+        retryCount = int.MinValue;
+        return false;
+    }
+}

--- a/Tennisi.Xunit.ParallelTestFramework/RetryClassAttribute.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/RetryClassAttribute.cs
@@ -1,0 +1,59 @@
+﻿using Xunit;
+using Xunit.Sdk;
+
+namespace Tennisi.Xunit;
+
+/// <summary>
+/// Represents a custom xUnit attribute to specify that all test methods 
+/// in the class (both facts and theories) should be retried a specified number of times.
+/// </summary>
+/// <remarks>
+/// This attribute is useful for test classes where tests may occasionally fail 
+/// due to transient issues such as network delays, timeouts, or other 
+/// external dependencies. When applied, each test method in the class, 
+/// including both <see cref="FactAttribute"/> and <see cref="TheoryAttribute"/> methods, 
+/// will be retried up to the specified <see cref="RetryCount"/> value upon failure.
+/// </remarks>
+/// <example>
+/// <code>
+/// [RetryClass(retryCount: 3)]
+/// public class MyTests
+/// {
+///     [Fact]
+///     public void TestMethod1()
+///     {
+///         // Test code for TestMethod1
+///     }
+///     
+///     [Theory]
+///     [InlineData(1)]
+///     [InlineData(2)]
+///     public void TestMethod2(int input)
+///     {
+///         // Test code for TestMethod2
+///     }
+/// }
+/// </code>
+/// </example>
+[XunitTestCaseDiscoverer("Tennisi.Xunit.RetryFactDiscoverer", "Tennisi.Xunit.ParallelTestFramework")]
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class RetryClassAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the number of times the test methods in the class should be retried.
+    /// </summary>
+    public int RetryCount { get; internal set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetryClassAttribute"/> class 
+    /// with the specified retry count.
+    /// </summary>
+    /// <param name="retryCount">The number of retry attempts for test methods in the class. Must be greater than one.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="retryCount"/> is less than or equal to one.
+    /// </exception>
+    public RetryClassAttribute(int retryCount)
+    {
+        RetryCount = RetryHelper.Verify(retryCount);
+    }
+}

--- a/Tennisi.Xunit.ParallelTestFramework/RetryClassAttribute.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/RetryClassAttribute.cs
@@ -35,7 +35,6 @@ namespace Tennisi.Xunit;
 /// }
 /// </code>
 /// </example>
-[XunitTestCaseDiscoverer("Tennisi.Xunit.RetryFactDiscoverer", "Tennisi.Xunit.ParallelTestFramework")]
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class RetryClassAttribute : Attribute
 {

--- a/Tennisi.Xunit.ParallelTestFramework/RetryFactAttribute.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/RetryFactAttribute.cs
@@ -1,0 +1,38 @@
+﻿using Xunit;
+using Xunit.Sdk;
+
+namespace Tennisi.Xunit;
+
+/// <summary>
+/// Represents a custom xUnit attribute to retry a test a specified number of times.
+/// </summary>
+/// <remarks>
+/// This attribute is useful for tests that may occasionally fail due to transient issues.
+/// When used, it will retry the test up to the specified <see cref="RetryCount"/> value.
+/// </remarks>
+/// <example>
+/// <code>
+/// [RetryFact(retryCount: 3)]
+/// public void TestMethod()
+/// {
+///     // Test code here
+/// }
+/// </code>
+/// </example>
+[XunitTestCaseDiscoverer("Tennisi.Xunit.RetryFactDiscoverer", "Tennisi.Xunit.ParallelTestFramework")]
+public sealed class RetryFactAttribute : FactAttribute
+{
+    public int RetryCount { get; internal set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetryFactAttribute"/> class with the specified retry count.
+    /// </summary>
+    /// <param name="retryCount">The number of retry attempts for the test. Must be greater than one.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="retryCount"/> is less than or equal to one.
+    /// </exception>
+    public RetryFactAttribute(int retryCount)
+    {
+        RetryCount = RetryHelper.Verify(retryCount);
+    }
+}

--- a/Tennisi.Xunit.ParallelTestFramework/RetryFactDiscoverer.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/RetryFactDiscoverer.cs
@@ -1,0 +1,23 @@
+﻿using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Tennisi.Xunit;
+
+public class RetryFactDiscoverer : IXunitTestCaseDiscoverer
+{
+    readonly IMessageSink _diagnosticMessageSink;
+
+    public RetryFactDiscoverer(IMessageSink diagnosticMessageSink)
+    {
+        this._diagnosticMessageSink = diagnosticMessageSink;
+    }
+
+    public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+    {
+        yield return 
+            new RetryTestCase(_diagnosticMessageSink,
+                discoveryOptions.MethodDisplayOrDefault(), 
+                discoveryOptions.MethodDisplayOptionsOrDefault(),
+                testMethod,null, factAttribute.GetRetryCount());
+    }
+}

--- a/Tennisi.Xunit.ParallelTestFramework/RetryHelper.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/RetryHelper.cs
@@ -5,7 +5,7 @@ namespace Tennisi.Xunit;
 internal static class RetryHelper
 {
     private const int DefaultRetryCount = 1;
-    private const int MaxRetryCount = 3;
+    private const int MaxRetryCount = 10;
     private const string RetryCountName = nameof(RetryTheoryAttribute.RetryCount); 
     
     internal static int GetRetryCount(this IAttributeInfo attributeInfo)

--- a/Tennisi.Xunit.ParallelTestFramework/RetryHelper.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/RetryHelper.cs
@@ -1,0 +1,45 @@
+﻿using Xunit.Abstractions;
+
+namespace Tennisi.Xunit;
+
+internal static class RetryHelper
+{
+    private const int DefaultRetryCount = 1;
+    private const int MaxRetryCount = 3;
+    private const string RetryCountName = nameof(RetryTheoryAttribute.RetryCount); 
+    
+    internal static int GetRetryCount(this IAttributeInfo attributeInfo)
+    {
+        return attributeInfo.GetNamedArgument<int>(RetryCountName);
+    }
+    
+    internal static bool IsDefaultRetryCount(this int value)
+    {
+        return value == DefaultRetryCount;
+    }
+    
+    internal static int GetRetryCountOrDefault(this IAttributeInfo? attributeInfo)
+    {
+        return attributeInfo?.GetRetryCount() ?? DefaultRetryCount;
+    }
+
+    internal static void AddRetryCount(this IXunitSerializationInfo serializationInfo, int retryCount)
+    {
+        serializationInfo.AddValue(RetryCountName, retryCount);
+    }
+    
+    internal static int GetRetryCount(this IXunitSerializationInfo serializationInfo)
+    {
+        return serializationInfo.GetValue<int>(RetryHelper.RetryCountName);
+    }
+    
+    internal static int Verify(int retryCount)
+    {
+        if (retryCount is < DefaultRetryCount or > MaxRetryCount)
+        {
+            throw new ArgumentException($"{nameof(retryCount)} must be between {DefaultRetryCount} and {MaxRetryCount}.", nameof(retryCount));
+        }
+        return retryCount;
+    }
+
+}

--- a/Tennisi.Xunit.ParallelTestFramework/RetryTestCase.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/RetryTestCase.cs
@@ -46,6 +46,8 @@ internal class RetryTestCase : IXunitTestCase
 
             diagnosticMessageSink.OnMessage(
                 new DiagnosticMessage("Execution of '{0}' failed (attempt #{1}), test retrying...", DisplayName, runCount));
+
+            await Task.Delay(1, cancellationTokenSource.Token);
         }
     }
 

--- a/Tennisi.Xunit.ParallelTestFramework/RetryTestCase.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/RetryTestCase.cs
@@ -1,0 +1,80 @@
+﻿using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Tennisi.Xunit;
+
+[Serializable]
+internal class RetryTestCase : IXunitTestCase
+{
+    private int _retryCount;
+    private IXunitTestCase _realCase;
+    
+    public RetryTestCase(IXunitTestCase baseCase, int retryCount)
+    {
+        _realCase = baseCase;
+        _retryCount = retryCount;
+    }
+
+    public RetryTestCase(IMessageSink diagnosticMessageSink,
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod, object[] testMethodArguments, int retryCount)
+    {
+        _realCase = new XunitTestCase(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments);
+        _retryCount = retryCount;
+    }
+    
+    public async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+        IMessageBus messageBus,
+        object[] constructorArguments,
+        ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        var runCount = 0;
+
+        while (true)
+        {
+            var delayedMessageBus = new DelayedMessageBus(messageBus);
+
+            var summary = await _realCase.RunAsync(diagnosticMessageSink, delayedMessageBus, constructorArguments,
+                aggregator, cancellationTokenSource);
+            if (aggregator.HasExceptions || summary.Failed == 0 || ++runCount >= _retryCount)
+            {
+                delayedMessageBus.Dispose();
+                return summary;
+            }
+
+            diagnosticMessageSink.OnMessage(
+                new DiagnosticMessage("Execution of '{0}' failed (attempt #{1}), test retrying...", DisplayName, runCount));
+        }
+    }
+
+    public Exception InitializationException => _realCase.InitializationException;
+    public IMethodInfo Method => _realCase.Method;
+    public int Timeout => _realCase.Timeout;
+
+    public void Serialize(IXunitSerializationInfo data)
+    {
+        _realCase.Serialize(data);
+        data.AddRetryCount(_retryCount);
+    }
+
+    public void Deserialize(IXunitSerializationInfo data)
+    {
+        _realCase.Deserialize(data);
+        _retryCount = data.GetRetryCount();
+    }
+
+    public string DisplayName => _realCase.DisplayName;
+    public string SkipReason => _realCase.SkipReason;
+
+    public ISourceInformation SourceInformation
+    {
+        get => _realCase.SourceInformation;
+        set => _realCase.SourceInformation = value;
+    }
+    public ITestMethod TestMethod => _realCase.TestMethod;
+    public object[] TestMethodArguments => _realCase.TestMethodArguments;
+    public Dictionary<string, List<string>> Traits => _realCase.Traits;
+    public string UniqueID => _realCase.UniqueID;
+}

--- a/Tennisi.Xunit.ParallelTestFramework/RetryTheoryAttribute.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/RetryTheoryAttribute.cs
@@ -1,0 +1,40 @@
+﻿using Xunit;
+using Xunit.Sdk;
+
+namespace Tennisi.Xunit;
+
+/// <summary>
+/// Represents a custom xUnit attribute to retry a theory test a specified number of times.
+/// </summary>
+/// <remarks>
+/// This attribute is useful for theory tests that may occasionally fail due to transient issues.
+/// When used, it will retry the test up to the specified <see cref="RetryCount"/> value for each set of inputs.
+/// </remarks>
+/// <example>
+/// <code>
+/// [RetryTheory(retryCount: 3)]
+/// [InlineData(1)]
+/// [InlineData(2)]
+/// public void TestMethod(int input)
+/// {
+///     // Test code here
+/// }
+/// </code>
+/// </example>
+[XunitTestCaseDiscoverer("Tennisi.Xunit.RetryTheoryDiscoverer", "Tennisi.Xunit.ParallelTestFramework")]
+public sealed class RetryTheoryAttribute : TheoryAttribute
+{
+    public int RetryCount { get; internal set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetryTheoryAttribute"/> class with the specified retry count.
+    /// </summary>
+    /// <param name="retryCount">The number of retry attempts for the test. Must be greater than one.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="retryCount"/> is less than or equal to one.
+    /// </exception>
+    public RetryTheoryAttribute(int retryCount)
+    {
+        RetryCount = RetryHelper.Verify(retryCount);
+    }
+}

--- a/Tennisi.Xunit.ParallelTestFramework/RetryTheoryDiscoverer.cs
+++ b/Tennisi.Xunit.ParallelTestFramework/RetryTheoryDiscoverer.cs
@@ -1,0 +1,21 @@
+﻿using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Tennisi.Xunit;
+
+internal class RetryTheoryDiscoverer : TheoryDiscoverer
+{
+    public RetryTheoryDiscoverer(IMessageSink diagnosticMessageSink)
+        : base(diagnosticMessageSink)
+    { }
+
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
+    {
+        yield return 
+            new RetryTestCase(DiagnosticMessageSink,
+                discoveryOptions.MethodDisplayOrDefault(), 
+                discoveryOptions.MethodDisplayOptionsOrDefault(),
+                testMethod,
+                dataRow,theoryAttribute.GetRetryCount());
+    }
+}

--- a/Tennisi.Xunit.ParallelTestFramework/Tennisi.Xunit.ParallelTestFramework.csproj
+++ b/Tennisi.Xunit.ParallelTestFramework/Tennisi.Xunit.ParallelTestFramework.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.9.2" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Ни одного теста не скипнуто.

Для подробной информации см. в метаданных Tennisi.Xunit.ParallelTestFramework
RetryFactAttribute, RetryTheoryAttribute, RetryClassAttribute

RetryFactAttribute используется вместо стандратного FactAttribute с указанием макс. кол-ва попыток.

RetryTheoryAttribute использется вместо стандратного TheoryAttrubute с указанием макс. кол-ва попыток. _[Работает только с xunit.discovery.PreEnumerateTheories или FullTestParallelization]_

RetryClassAttribute использется для указания макс. кол-ва попыток всем фактам и теориям в тестовом классе, если они не определены для тестовых методов.

В Логах ищи **test retrying...** что бы найти подозрительные тесты

Применение retry аттрибута не означает решения, по ответственности и codeowner'a приравено k skip аттрибута.
